### PR TITLE
Add extra librope tests

### DIFF
--- a/subprojects/librope/test/cursor.c
+++ b/subprojects/librope/test/cursor.c
@@ -135,12 +135,42 @@ cursor_event() {
 	ASSERT_EQ(0, rv);
 	rv = rope_cursor_cleanup(&c2);
 	ASSERT_EQ(0, rv);
-	rv = rope_cleanup(&r);
-	ASSERT_EQ(0, rv);
+        rv = rope_cleanup(&r);
+        ASSERT_EQ(0, rv);
+}
+
+static void
+cursor_move_codepoint() {
+        int rv = 0;
+        struct Rope r = {0};
+        rv = rope_init(&r);
+        ASSERT_EQ(0, rv);
+
+        rv = rope_append_str(&r, "ABC");
+        ASSERT_EQ(0, rv);
+
+        struct RopeCursor c = {0};
+        rv = rope_cursor_init(&c, &r);
+        ASSERT_EQ(0, rv);
+
+        rv = rope_cursor_move_to_index(&c, 1);
+        ASSERT_EQ(0, rv);
+        int32_t cp = rope_cursor_codepoint(&c);
+        ASSERT_EQ('B', cp);
+
+        rv = rope_cursor_move(&c, -2);
+        ASSERT_EQ(0, rv);
+        ASSERT_EQ((size_t)0, c.index);
+
+        rv = rope_cursor_cleanup(&c);
+        ASSERT_EQ(0, rv);
+        rv = rope_cleanup(&r);
+        ASSERT_EQ(0, rv);
 }
 
 DECLARE_TESTS
 TEST(cursor_basic)
 TEST(cursor_utf8)
 TEST(cursor_event)
+TEST(cursor_move_codepoint)
 END_TESTS

--- a/subprojects/librope/test/iterator.c
+++ b/subprojects/librope/test/iterator.c
@@ -21,6 +21,47 @@ test_iterator_simple() {
 	rv = rope_range_cleanup(&range);
 }
 
+static void
+test_iterator_collect() {
+        int rv = 0;
+        struct Rope r = {0};
+        rv = rope_init(&r);
+        ASSERT_EQ(0, rv);
+
+        rv = rope_append_str(&r, "Hello ");
+        ASSERT_EQ(0, rv);
+        rv = rope_append_str(&r, "World");
+        ASSERT_EQ(0, rv);
+
+        struct RopeRange range = {0};
+        rv = rope_range_init(&range, &r, NULL, NULL, NULL);
+        ASSERT_EQ(0, rv);
+        rv = rope_cursor_move_to_index(rope_range_end(&range), rope_char_size(&r));
+        ASSERT_EQ(0, rv);
+
+        struct RopeIterator iter = {0};
+        rv = rope_iterator_init(&iter, &range);
+        ASSERT_EQ(0, rv);
+
+        char result[32] = {0};
+        size_t offset = 0;
+        const uint8_t *value = NULL;
+        size_t size = 0;
+        while (rope_iterator_next(&iter, &value, &size)) {
+                memcpy(&result[offset], value, size);
+                offset += size;
+        }
+        ASSERT_STREQ("Hello World", result);
+
+        rv = rope_iterator_cleanup(&iter);
+        ASSERT_EQ(0, rv);
+        rv = rope_range_cleanup(&range);
+        ASSERT_EQ(0, rv);
+        rv = rope_cleanup(&r);
+        ASSERT_EQ(0, rv);
+}
+
 DECLARE_TESTS
 TEST(test_iterator_simple)
+TEST(test_iterator_collect)
 END_TESTS

--- a/subprojects/librope/test/range.c
+++ b/subprojects/librope/test/range.c
@@ -2,6 +2,8 @@
 #include <string.h>
 #include <testlib.h>
 
+static void noop_range_cb(struct Rope *r, struct RopeRange *range, void *ud);
+
 static void
 range_basic() {
 	int rv = 0;
@@ -12,8 +14,8 @@ range_basic() {
 	rv = rope_append_str(&r, "Hello World This is a string");
 	ASSERT_EQ(0, rv);
 
-	struct RopeRange range = {0};
-	rv = rope_range_init(&range, &r, NULL, NULL, NULL);
+        struct RopeRange range = {0};
+        rv = rope_range_init(&range, &r, noop_range_cb, noop_range_cb, NULL);
 	ASSERT_EQ(0, rv);
 
 	rv = rope_range_cleanup(&range);
@@ -22,6 +24,49 @@ range_basic() {
 	ASSERT_EQ(0, rv);
 }
 
+static void noop_range_cb(struct Rope *r, struct RopeRange *range, void *ud) {
+        (void)r;
+        (void)range;
+        (void)ud;
+}
+
+static void
+range_insert_delete() {
+        int rv = 0;
+        struct Rope r = {0};
+        rv = rope_init(&r);
+        ASSERT_EQ(0, rv);
+
+        struct RopeRange range = {0};
+        rv = rope_range_init(&range, &r, noop_range_cb, noop_range_cb, NULL);
+        ASSERT_EQ(0, rv);
+
+        rv = rope_range_insert_str(&range, "Hello");
+        ASSERT_EQ(0, rv);
+
+        struct RopeNode *node = rope_first(&r);
+        size_t size = 0;
+        const uint8_t *data = rope_node_value(node, &size);
+        ASSERT_EQ(0, memcmp(data, "Hello", size));
+
+        rv = rope_cursor_move_to_index(rope_range_end(&range), rope_char_size(&r));
+        ASSERT_EQ(0, rv);
+        rv = rope_cursor_move_to_index(rope_range_start(&range), 0);
+        ASSERT_EQ(0, rv);
+        rv = rope_range_delete(&range);
+        ASSERT_EQ(0, rv);
+
+        node = rope_first(&r);
+        data = rope_node_value(node, &size);
+        ASSERT_EQ((size_t)0, size);
+
+        rv = rope_range_cleanup(&range);
+        ASSERT_EQ(0, rv);
+        rv = rope_cleanup(&r);
+        ASSERT_EQ(0, rv);
+}
+
 DECLARE_TESTS
 TEST(range_basic)
+TEST(range_insert_delete)
 END_TESTS


### PR DESCRIPTION
## Summary
- expand librope range tests
- test iterator output
- test cursor move and codepoint operations

## Testing
- `meson test -C build --no-rebuild`

------
https://chatgpt.com/codex/tasks/task_e_685267020d408323af96179d76b9b4ad